### PR TITLE
Use `document.activeElement.closest` to check for editor focus

### DIFF
--- a/lib/refactorjs-view.js
+++ b/lib/refactorjs-view.js
@@ -43,7 +43,7 @@ export default class RefactorjsView {
   }
 
   focusNext () {
-    this.searchInput === document.activeElement ? this.replaceInput.focus() : this.searchInput.focus();
+    this.searchInput === document.activeElement.closest('atom-text-editor') ? this.replaceInput.focus() : this.searchInput.focus();
   }
 
   search () {


### PR DESCRIPTION
As part of https://github.com/atom/atom/pull/12903, the Atom team is planning on removing the shadow DOM from `<atom-text-editor>`. This will have an important effect on `document.activeElement`, as it will now stop returning an `atom-text-editor` element and return its hidden `<input>` element instead when an editor is focused.

This pull request fixes this package (in a backward compatible manner) so that when we ship that change (likely, in Atom 1.13) everything will keep working as expected.

I'm happy to help in case you have any questions about the aforementioned change. Thanks! ✨ 
